### PR TITLE
guest checkout/order flow fixed

### DIFF
--- a/app/components/checkout/AddressForm.js
+++ b/app/components/checkout/AddressForm.js
@@ -17,17 +17,17 @@ const AddressForm = (props) => {
   const shippingAddress = useSelector(state => state.shippingAddress);
   const [name, setName] = useState(shippingAddress.name || '');
   const [line1, setLine1] = useState(shippingAddress.line1 || '');
-  const [line2, setLine2] = useState(shippingAddress.line2 ||'');
-  const [city, setCity] = useState(shippingAddress.city ||'');
+  const [line2, setLine2] = useState(shippingAddress.line2 || '');
+  const [city, setCity] = useState(shippingAddress.city || '');
   const [state, setShippingState] = useState(shippingAddress.state || 'AL');
-  const [zip, setZip] = useState(shippingAddress.zip ||'');
+  const [zip, setZip] = useState(shippingAddress.zip || '');
   const dispatch = useDispatch();
   const user = useSelector(state => state.user);
 
   const handleSubmit = () => {
     shippingAddress ?
-    dispatch(updateShippingAddress({ name, line1, line2, city, state, zip, userId: user.id }))
-    : dispatch(postShippingAddress({ name, line1, line2, city, state, zip, userId: user.id }))
+      dispatch(updateShippingAddress({ name, line1, line2, city, state, zip }))
+      : dispatch(postShippingAddress({ name, line1, line2, city, state, zip }))
   }
 
   return (
@@ -88,10 +88,10 @@ const AddressForm = (props) => {
               name="state"
               value={state}
               onChange={(ev) => setShippingState(ev.target.value)}
-              >
-                {
-                  states.map(stateSymb => <MenuItem key={stateSymb} value={stateSymb}>{stateSymb}</MenuItem>)
-                }
+            >
+              {
+                states.map(stateSymb => <MenuItem key={stateSymb} value={stateSymb}>{stateSymb}</MenuItem>)
+              }
             </Select>
           </FormControl>
         </Grid>

--- a/app/redux/shippingAddress.js
+++ b/app/redux/shippingAddress.js
@@ -7,46 +7,46 @@ const initState = '';
 
 //action creator
 export const setShippingAddress = (shippingAddress) => {
-    return {
-        type: SET_SHIPPING_ADDRESS,
-        shippingAddress
-    }
+  return {
+    type: SET_SHIPPING_ADDRESS,
+    shippingAddress
+  }
 };
 
 //thunks
 export const fetchShippingAddress = (userId) => {
-    return (dispatch, getState, {axios}) => {
-        return axios.get(`/api/shippingaddress/${userId}`)
-            .then(response => response.data)
-            .then(address => dispatch(setShippingAddress(address)))
-            .catch(e => console.log(chalk.red('error: fetchShippingAddress thunk failed')))
-    }
+  return (dispatch, getState, { axios }) => {
+    return axios.get(`/api/shippingaddress/${userId}`)
+      .then(response => response.data)
+      .then(address => dispatch(setShippingAddress(address)))
+      .catch(e => console.log(chalk.red('error: fetchShippingAddress thunk failed')))
+  }
 };
 
-export const postShippingAddress = (address, userId) => {
-    return (dispatch, getState, {axios}) => {
-        return axios.post('/api/shippingaddress', address)
-            .then(response => response.data)
-            .then(address => dispatch(setShippingAddress(address)))
-            .catch(e => console.log(chalk.red('error: setShippingAddress thunk failed')))
-    }
+export const postShippingAddress = (address) => {
+  return (dispatch, getState, { axios }) => {
+    return axios.post('/api/shippingaddress', address)
+      .then(response => response.data)
+      .then(address => dispatch(setShippingAddress(address)))
+      .catch(e => console.log(chalk.red('error: setShippingAddress thunk failed')))
+  }
 };
 
 export const updateShippingAddress = (address) => {
-    return (dispatch, getState, {axios}) => {
-        return axios.put(`/api/shippingaddress/${userId}`, { address })
-        .then(response => response.data)
-        .then(address => dispatch(setShippingAddress(address)))
-        .catch(e => console.log(chalk.red('error: setShippingAddress thunk failed')))
-    }
+  return (dispatch, getState, { axios }) => {
+    return axios.put(`/api/shippingaddress/${userId}`, { address })
+      .then(response => response.data)
+      .then(address => dispatch(setShippingAddress(address)))
+      .catch(e => console.log(chalk.red('error: setShippingAddress thunk failed')))
+  }
 };
 
 //reducer
 export const shippingAddressReducer = (state = initState, action) => {
-    switch (action.type) {
-      case SET_SHIPPING_ADDRESS:
-        return action.shippingAddress;
-      default:
-        return state;
-    }
+  switch (action.type) {
+    case SET_SHIPPING_ADDRESS:
+      return action.shippingAddress;
+    default:
+      return state;
+  }
 };

--- a/db/index.js
+++ b/db/index.js
@@ -20,6 +20,8 @@ OrderItem.belongsTo(Product);
 
 ShippingAddress.belongsTo(User);
 User.hasMany(ShippingAddress);
+ShippingAddress.belongsTo(Session);
+Session.hasOne(ShippingAddress);
 
 Session.hasOne(User);
 User.belongsTo(Session);

--- a/server/api/order.js
+++ b/server/api/order.js
@@ -97,17 +97,32 @@ router.get('/', (req, res, next) => {
 
 //create new order
 router.post('/', (req, res, next) => {
-  Order.create({
-    status: req.body.status || 'pending',
-    userId: req.user.id,
-  })
-    .then(created => {
-      res.status(201).send(created);
+  if (req.user) {
+    Order.create({
+      status: req.body.status || 'pending',
+      userId: req.user.id,
     })
-    .catch(e => {
-      res.status(400).send('Invalid request');
-      next(e);
+      .then(created => {
+        res.status(201).send(created);
+      })
+      .catch(e => {
+        res.status(400).send('Invalid request');
+        next(e);
+      })
+  }
+  else {
+    Order.create({
+      status: req.body.status || 'pending',
+      sessionId: req.cookies.sessionId,
     })
+      .then(created => {
+        res.status(201).send(created);
+      })
+      .catch(e => {
+        res.status(400).send('Invalid request');
+        next(e);
+      })
+  }
 });
 
 //Update an order

--- a/server/api/shippingAddress.js
+++ b/server/api/shippingAddress.js
@@ -5,13 +5,23 @@ const { ShippingAddress, User } = require('../../db/models/index')
 // create shipping address
 
 router.post('/', (req, res, next) => {
-  const { name, line1, line2, city, state, zip, userId } = req.body;
-  if (!name || !line1 || !city || !state || !zip || !userId) {
-    res.status(400).send('Invalid request. Name, Address line 1, City, State, Zipcode and UserId are required fields. Please try again with all required fields.')
+  const { name, line1, line2, city, state, zip } = req.body;
+  if (!name || !line1 || !city || !state || !zip) {
+    return res.status(400).send('Invalid request. Name, Address line 1, City, State and Zipcode are required fields. Please try again with all required fields.')
+  }
+  if (req.user) {
+    ShippingAddress.create({ name, line1, line2, city, state, zip, userId: req.user.id })
+      .then(address => res.status(201).send(address))
+      .catch(e => {
+        res.status(400).send('Error creating shipping address');
+        next(e)
+      })
   }
   else {
-    ShippingAddress.create({ name, line1, line2, city, state, zip, userId })
-      .then(address => res.status(201).send(address))
+    ShippingAddress.create({ name, line1, line2, city, state, zip, sessionId: req.cookies.sessionId })
+      .then(address => {
+        res.status(201).send(address)
+      })
       .catch(e => {
         res.status(400).send('Error creating shipping address');
         next(e)


### PR DESCRIPTION
- Model associations updated to add sessionId/shippingAddress relationship (don't forget to run `npm run seed`)
- shippingAddress thunks updated
- shippingAddress and order routes updated

Two things to note:

1. if you get an error after re-seeding (cart/sessionId association), clear your cookies and refresh and it should work fine. this is an edge case bug we still need to figure out

2. If user begins as guest, adds items to cart, then logs in, Cart contents don't transfer over into their pre-existing cart. I can get to that next.